### PR TITLE
Add filter-aware schema fetcher infrastructure

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/DBSchemaInfoFetcherFactory.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/DBSchemaInfoFetcherFactory.java
@@ -31,7 +31,9 @@
 package com.cubrid.cubridmigration.core.dbmetadata;
 
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.AbstractJDBCSchemaFetcher;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.mysql.MysqlXmlDumpSource;
 import com.cubrid.cubridmigration.mysql.meta.MYSQLXMLSchemaFether;
 
@@ -72,5 +74,22 @@ public final class DBSchemaInfoFetcherFactory {
             return new MYSQLXMLSchemaFether();
         }
         return NA_FETCHER;
+    }
+
+    /**
+     * Return JDBC schema fetcher for the given connection parameters.
+     *
+     * @param cp ConnParameters
+     * @return JDBC schema fetcher or null when database type is unknown
+     */
+    public static AbstractJDBCSchemaFetcher getJdbcFetcher(ConnParameters cp) {
+        if (cp == null) {
+            throw new IllegalArgumentException("ConnParameters must not be null");
+        }
+        DatabaseType dt = cp.getDatabaseType();
+        if (dt == null) {
+            return null;
+        }
+        return dt.getMetaDataBuilder();
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
@@ -32,8 +32,12 @@ package com.cubrid.cubridmigration.core.dbmetadata;
 
 import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.AbstractJDBCSchemaFetcher;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+
+import java.util.Collections;
+import java.util.List;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -101,5 +105,22 @@ public class JDBCDBSchemaFetcherFacade implements IDBSchemaInfoFetcher {
             cancelRunable.run();
             cancelRunable = null;
         }
+    }
+
+    /**
+     * List available schema names for the given JDBC connection parameters.
+     *
+     * @param cp JDBC connection parameters
+     * @return schema name list, empty when builder is not available
+     */
+    public List<String> listSchemaNames(ConnParameters cp) {
+        if (cp == null) {
+            return Collections.emptyList();
+        }
+        AbstractJDBCSchemaFetcher builder = DBSchemaInfoFetcherFactory.getJdbcFetcher(cp);
+        if (builder == null) {
+            return Collections.emptyList();
+        }
+        return builder.getAllSchemaNames(cp);
     }
 }

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/SchemaFetcherWithProgress.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/SchemaFetcherWithProgress.java
@@ -33,6 +33,7 @@ package com.cubrid.cubridmigration.ui.database;
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbmetadata.DBSchemaInfoFetcherFactory;
+import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSchemaInfoFetcher;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSource;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
@@ -64,6 +65,7 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
     protected boolean isFinished;
     protected Exception exception;
     protected String errorMessage;
+    private IBuildSchemaFilter activeFilter;
 
     protected SchemaFetcherWithProgress() {
         //
@@ -133,11 +135,12 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
     protected Thread startFetchingThread(
             final IDBSchemaInfoFetcher fetcher, final IProgressMonitor pm) {
         pm.beginTask(Messages.progressMetadata, IProgressMonitor.UNKNOWN);
+        final IBuildSchemaFilter filter = activeFilter;
         Thread thread =
                 new Thread("Cancel progress") {
                     public void run() {
                         try {
-                            catalog = fetcher.fetchSchema(dbSource, null);
+                            catalog = fetcher.fetchSchema(dbSource, filter);
                         } catch (Exception ex) {
                             exception = ex;
                             LOG.error("", ex);
@@ -156,7 +159,19 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
      * @return Catalog
      */
     public Catalog fetch() {
+        return fetch(null);
+    }
+
+    /**
+     * return catalog with progress dialog
+     *
+     * @param filter schema filter
+     * @return Catalog
+     */
+    public Catalog fetch(IBuildSchemaFilter filter) {
+        activeFilter = filter;
         CompositeUtils.runMethodInProgressBar(true, true, this);
+        activeFilter = null;
         return catalog;
     }
 


### PR DESCRIPTION
## Summary
- extend `SchemaFetcherWithProgress` to accept an optional `IBuildSchemaFilter`
- expose JDBC metadata builders via `DBSchemaInfoFetcherFactory` for reuse
- add `JDBCDBSchemaFetcherFacade.listSchemaNames` to surface schema name enumeration

## Testing
- `mvn -pl plugins/com.cubrid.cubridmigration.ui -am -DskipTests compile` *(fails: missing org.eclipse.tycho:tycho-maven-plugin:4.0.13 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f119ae7c8323998c9f0522e7af91)