### PR TITLE
Add session and loaders for source schema metadata

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectionMgrView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectionMgrView.java
@@ -34,6 +34,7 @@ import com.cubrid.common.log.LogUtil;
 import com.cubrid.common.ui.swt.table.TableViewerBuilder;
 import com.cubrid.cubridmigration.core.connection.CMTConParamManager;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.ui.MigrationUIPlugin;
@@ -688,8 +689,12 @@ public class JDBCConnectionMgrView {
      * @param cp connection parameters.
      */
     private void updateConParamCatalog(ConnParameters cp) {
+        updateConParamCatalog(cp, null);
+    }
+
+    private void updateConParamCatalog(ConnParameters cp, IBuildSchemaFilter filter) {
         final CMTConParamManager cpm = CMTConParamManager.getInstance();
-        SchemaFetcherWithProgress fetcher = SchemaFetcherWithProgress.getInstance(cp);
+        SchemaFetcherWithProgress fetcher = SchemaFetcherWithProgress.getInstance(cp, filter);
         Catalog catalog = fetcher.fetch();
 
         // If fetch catalog successfully, update cache and return.

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/MysqlXmlDumpSchemaProgressFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/MysqlXmlDumpSchemaProgressFetcher.java
@@ -136,7 +136,7 @@ public class MysqlXmlDumpSchemaProgressFetcher extends SchemaFetcherWithProgress
                         try {
                             MysqlXmlDumpSource tempDs = ((MysqlXmlDumpSource) dbSource).clone();
                             tempDs.setEvent(readerEvent);
-                            catalog = fetcher.fetchSchema(tempDs, null);
+                            catalog = fetcher.fetchSchema(tempDs, filter);
                         } catch (Exception ex) {
                             exception = ex;
                         } finally {

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/SchemaFetcherWithProgress.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/SchemaFetcherWithProgress.java
@@ -33,6 +33,7 @@ package com.cubrid.cubridmigration.ui.database;
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbmetadata.DBSchemaInfoFetcherFactory;
+import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSchemaInfoFetcher;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSource;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
@@ -64,6 +65,7 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
     protected boolean isFinished;
     protected Exception exception;
     protected String errorMessage;
+    protected IBuildSchemaFilter filter;
 
     protected SchemaFetcherWithProgress() {
         //
@@ -137,7 +139,7 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
                 new Thread("Cancel progress") {
                     public void run() {
                         try {
-                            catalog = fetcher.fetchSchema(dbSource, null);
+                            catalog = fetcher.fetchSchema(dbSource, filter);
                         } catch (Exception ex) {
                             exception = ex;
                             LOG.error("", ex);
@@ -189,6 +191,10 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
         this.dbSource = ds;
     }
 
+    protected void setFilter(IBuildSchemaFilter filter) {
+        this.filter = filter;
+    }
+
     public String getErrorMessage() {
         return errorMessage;
     }
@@ -204,8 +210,14 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
      * @return SchemaFetcherWithProgress
      */
     public static SchemaFetcherWithProgress getInstance(IDBSource ds) {
+        return getInstance(ds, null);
+    }
+
+    public static SchemaFetcherWithProgress getInstance(
+            IDBSource ds, IBuildSchemaFilter filter) {
         SchemaFetcherWithProgress runnable = new SchemaFetcherWithProgress();
         runnable.setDBSource(ds);
+        runnable.setFilter(filter);
         return runnable;
     }
 
@@ -217,8 +229,13 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
      * @return Catalog
      */
     public static Catalog fetch(IDBSource ds) {
+        return fetch(ds, null);
+    }
+
+    public static Catalog fetch(IDBSource ds, IBuildSchemaFilter filter) {
         SchemaFetcherWithProgress runnable = new SchemaFetcherWithProgress();
         runnable.setDBSource(ds);
+        runnable.setFilter(filter);
         Catalog catalog = runnable.fetch();
         if (catalog == null && runnable.exception != null) {
             runnable.openErrorDialog(runnable.errorMessage, runnable.exception.getMessage());

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SchemaDetailLoader.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SchemaDetailLoader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation.
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+package com.cubrid.cubridmigration.ui.source;
+
+import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import com.cubrid.cubridmigration.ui.database.SchemaFetcherWithProgress;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Fetches detailed schema metadata and merges it into a session cache.
+ */
+public class SchemaDetailLoader {
+
+    public Catalog load(SourceMetadataSession session, Collection<String> schemaNames) {
+        IBuildSchemaFilter filter = buildFilter(schemaNames);
+        SchemaFetcherWithProgress fetcher =
+                SchemaFetcherWithProgress.getInstance(session.getConnParameters(), filter);
+        Catalog catalog = fetcher.fetch();
+        if (catalog != null) {
+            session.mergeSchemas(catalog.getSchemas());
+        }
+        return catalog;
+    }
+
+    private IBuildSchemaFilter buildFilter(Collection<String> schemaNames) {
+        if (schemaNames == null || schemaNames.isEmpty()) {
+            return null;
+        }
+        final Set<String> normalized = normalize(schemaNames);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return new IBuildSchemaFilter() {
+
+            public boolean filter(String schema, String objName) {
+                if (schema == null) {
+                    return false;
+                }
+                return !normalized.contains(schema.toUpperCase(Locale.US));
+            }
+        };
+    }
+
+    private Set<String> normalize(Collection<String> schemaNames) {
+        if (schemaNames == null || schemaNames.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> result = new LinkedHashSet<String>();
+        for (String schemaName : schemaNames) {
+            if (schemaName == null) {
+                continue;
+            }
+            result.add(schemaName.toUpperCase(Locale.US));
+        }
+        return result;
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SchemaSummary.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SchemaSummary.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation.
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+package com.cubrid.cubridmigration.ui.source;
+
+/**
+ * Minimal DTO describing a schema entry that can be presented in the UI.
+ */
+public class SchemaSummary {
+
+    private final String name;
+    private boolean detailsLoaded;
+
+    public SchemaSummary(String name) {
+        this(name, false);
+    }
+
+    public SchemaSummary(String name, boolean detailsLoaded) {
+        this.name = name;
+        this.detailsLoaded = detailsLoaded;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isDetailsLoaded() {
+        return detailsLoaded;
+    }
+
+    public void setDetailsLoaded(boolean detailsLoaded) {
+        this.detailsLoaded = detailsLoaded;
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SchemaSummaryLoader.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SchemaSummaryLoader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation.
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+package com.cubrid.cubridmigration.ui.source;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.AbstractJDBCSchemaFetcher;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads summary information for available schemas from a source connection.
+ */
+public class SchemaSummaryLoader {
+
+    public List<SchemaSummary> load(SourceMetadataSession session) {
+        ConnParameters cp = session.getConnParameters();
+        DatabaseType databaseType = cp.getDatabaseType();
+        AbstractJDBCSchemaFetcher fetcher = databaseType.getMetaDataBuilder();
+        List<String> schemaNames = fetcher.getAllSchemaNames(cp);
+
+        List<SchemaSummary> summaries = new ArrayList<SchemaSummary>(schemaNames.size());
+        for (String schemaName : schemaNames) {
+            summaries.add(new SchemaSummary(schemaName));
+        }
+        session.setSchemaSummaries(summaries);
+        return session.getSchemaSummaries();
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SourceMetadataSession.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/source/SourceMetadataSession.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation.
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+package com.cubrid.cubridmigration.ui.source;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbobject.Schema;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Session object storing the source metadata retrieved during a wizard session.
+ */
+public class SourceMetadataSession {
+
+    private final ConnParameters connParameters;
+    private final Map<String, SchemaSummary> summariesByName = new LinkedHashMap<String, SchemaSummary>();
+    private final Map<String, Schema> schemaCache = new LinkedHashMap<String, Schema>();
+
+    public SourceMetadataSession(ConnParameters connParameters) {
+        this.connParameters = connParameters;
+    }
+
+    public ConnParameters getConnParameters() {
+        return connParameters;
+    }
+
+    public List<SchemaSummary> getSchemaSummaries() {
+        return Collections.unmodifiableList(new ArrayList<SchemaSummary>(summariesByName.values()));
+    }
+
+    public void setSchemaSummaries(Collection<SchemaSummary> summaries) {
+        summariesByName.clear();
+        if (summaries == null) {
+            return;
+        }
+        for (SchemaSummary summary : summaries) {
+            if (summary == null || summary.getName() == null) {
+                continue;
+            }
+            SchemaSummary stored =
+                    new SchemaSummary(summary.getName(), isSchemaCached(summary.getName()));
+            summariesByName.put(normalize(summary.getName()), stored);
+        }
+    }
+
+    public Schema getCachedSchema(String schemaName) {
+        return schemaCache.get(normalize(schemaName));
+    }
+
+    public boolean isSchemaCached(String schemaName) {
+        return schemaCache.containsKey(normalize(schemaName));
+    }
+
+    public void clearSchemaCache() {
+        schemaCache.clear();
+        for (SchemaSummary summary : summariesByName.values()) {
+            summary.setDetailsLoaded(false);
+        }
+    }
+
+    public void mergeSchemas(Collection<Schema> schemas) {
+        if (schemas == null) {
+            return;
+        }
+        for (Schema schema : schemas) {
+            if (schema == null || schema.getName() == null) {
+                continue;
+            }
+            String key = normalize(schema.getName());
+            schemaCache.put(key, schema);
+
+            SchemaSummary summary = summariesByName.get(key);
+            if (summary == null) {
+                summary = new SchemaSummary(schema.getName(), true);
+                summariesByName.put(key, summary);
+            } else {
+                summary.setDetailsLoaded(true);
+            }
+        }
+    }
+
+    private String normalize(String schemaName) {
+        if (schemaName == null) {
+            return "";
+        }
+        return schemaName.toUpperCase(Locale.US);
+    }
+}


### PR DESCRIPTION
## Summary
- add a SourceMetadataSession along with schema summary and detail loaders to cache JDBC metadata
- extend SchemaFetcherWithProgress, JDBCConnectionMgrView, and the MySQL XML fetcher to accept optional schema filters
- populate schema summaries via AbstractJDBCSchemaFetcher.getAllSchemaNames before loading detailed metadata

## Testing
- mvn -pl plugins/com.cubrid.cubridmigration.ui -am -DskipTests compile *(fails: unable to resolve org.eclipse.tycho:tycho-maven-plugin without network access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ce84a8848323a6924f22b36af69a)