### PR TITLE
Seed metadata session during online source save

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/DBSchemaInfoFetcherFactory.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/DBSchemaInfoFetcherFactory.java
@@ -31,7 +31,9 @@
 package com.cubrid.cubridmigration.core.dbmetadata;
 
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.AbstractJDBCSchemaFetcher;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.mysql.MysqlXmlDumpSource;
 import com.cubrid.cubridmigration.mysql.meta.MYSQLXMLSchemaFether;
 
@@ -72,5 +74,22 @@ public final class DBSchemaInfoFetcherFactory {
             return new MYSQLXMLSchemaFether();
         }
         return NA_FETCHER;
+    }
+
+    /**
+     * Return JDBC schema fetcher for the given connection parameters.
+     *
+     * @param cp ConnParameters
+     * @return JDBC schema fetcher or null when database type is unknown
+     */
+    public static AbstractJDBCSchemaFetcher getJdbcFetcher(ConnParameters cp) {
+        if (cp == null) {
+            throw new IllegalArgumentException("ConnParameters must not be null");
+        }
+        DatabaseType dt = cp.getDatabaseType();
+        if (dt == null) {
+            return null;
+        }
+        return dt.getMetaDataBuilder();
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
@@ -32,8 +32,12 @@ package com.cubrid.cubridmigration.core.dbmetadata;
 
 import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.AbstractJDBCSchemaFetcher;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+
+import java.util.Collections;
+import java.util.List;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -101,5 +105,22 @@ public class JDBCDBSchemaFetcherFacade implements IDBSchemaInfoFetcher {
             cancelRunable.run();
             cancelRunable = null;
         }
+    }
+
+    /**
+     * List available schema names for the given JDBC connection parameters.
+     *
+     * @param cp JDBC connection parameters
+     * @return schema name list, empty when builder is not available
+     */
+    public List<String> listSchemaNames(ConnParameters cp) {
+        if (cp == null) {
+            return Collections.emptyList();
+        }
+        AbstractJDBCSchemaFetcher builder = DBSchemaInfoFetcherFactory.getJdbcFetcher(cp);
+        if (builder == null) {
+            return Collections.emptyList();
+        }
+        return builder.getAllSchemaNames(cp);
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/session/CatalogHeader.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/session/CatalogHeader.java
@@ -1,0 +1,66 @@
+package com.cubrid.cubridmigration.core.dbmetadata.session;
+
+import java.util.Objects;
+
+/**
+ * Lightweight description of a source catalog that can be cached while
+ * deferring the full schema tree.
+ */
+public class CatalogHeader {
+
+    private final String databaseName;
+    private final String databaseVersion;
+    private final String timeZoneId;
+
+    public CatalogHeader(String databaseName, String databaseVersion, String timeZoneId) {
+        this.databaseName = databaseName;
+        this.databaseVersion = databaseVersion;
+        this.timeZoneId = timeZoneId;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getDatabaseVersion() {
+        return databaseVersion;
+    }
+
+    public String getTimeZoneId() {
+        return timeZoneId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CatalogHeader)) {
+            return false;
+        }
+        CatalogHeader other = (CatalogHeader) obj;
+        return Objects.equals(databaseName, other.databaseName)
+                && Objects.equals(databaseVersion, other.databaseVersion)
+                && Objects.equals(timeZoneId, other.timeZoneId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(databaseName, databaseVersion, timeZoneId);
+    }
+
+    @Override
+    public String toString() {
+        return "CatalogHeader{"
+                + "databaseName='"
+                + databaseName
+                + '\''
+                + ", databaseVersion='"
+                + databaseVersion
+                + '\''
+                + ", timeZoneId='"
+                + timeZoneId
+                + '\''
+                + '}';
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/session/SourceMetadataSession.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/session/SourceMetadataSession.java
@@ -1,0 +1,78 @@
+package com.cubrid.cubridmigration.core.dbmetadata.session;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Holds metadata lookup context so that wizard pages can collaborate without
+ * eagerly materialising every schema.
+ */
+public class SourceMetadataSession {
+
+    private ConnParameters connParameters;
+    private CatalogHeader header;
+    private final Map<String, SourceSchemaSummary> summaries = new LinkedHashMap<>();
+    private final Map<String, Catalog> fragments = new LinkedHashMap<>();
+
+    public void reset(ConnParameters parameters) {
+        this.connParameters = parameters;
+        this.header = null;
+        summaries.clear();
+        fragments.clear();
+    }
+
+    public ConnParameters getConnParameters() {
+        return connParameters;
+    }
+
+    public CatalogHeader getHeader() {
+        return header;
+    }
+
+    public void setHeader(CatalogHeader header) {
+        this.header = header;
+    }
+
+    public void putSummary(SourceSchemaSummary summary) {
+        if (summary == null) {
+            return;
+        }
+        summaries.put(summary.getSchemaName(), summary);
+    }
+
+    public SourceSchemaSummary getSummary(String schemaName) {
+        return summaries.get(schemaName);
+    }
+
+    public Collection<SourceSchemaSummary> getSummaries() {
+        return Collections.unmodifiableCollection(summaries.values());
+    }
+
+    public Map<String, SourceSchemaSummary> getSummaryMap() {
+        return Collections.unmodifiableMap(summaries);
+    }
+
+    public void putFragment(String schemaName, Catalog catalog) {
+        if (schemaName == null || catalog == null) {
+            return;
+        }
+        fragments.put(schemaName, catalog);
+    }
+
+    public Catalog getFragment(String schemaName) {
+        return fragments.get(schemaName);
+    }
+
+    public Map<String, Catalog> getFragments() {
+        return Collections.unmodifiableMap(fragments);
+    }
+
+    public boolean isActiveFor(ConnParameters parameters) {
+        return Objects.equals(connParameters, parameters);
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/session/SourceSchemaSummary.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/session/SourceSchemaSummary.java
@@ -1,0 +1,80 @@
+package com.cubrid.cubridmigration.core.dbmetadata.session;
+
+import java.util.Objects;
+
+/**
+ * Lightweight status holder for a source schema.
+ */
+public class SourceSchemaSummary {
+
+    public enum LoadState {
+        NOT_LOADED,
+        LOADING,
+        LOADED,
+        FAILED
+    }
+
+    private final String schemaName;
+    private boolean selected;
+    private LoadState loadState;
+
+    public SourceSchemaSummary(String schemaName) {
+        this(schemaName, false, LoadState.NOT_LOADED);
+    }
+
+    public SourceSchemaSummary(String schemaName, boolean selected, LoadState loadState) {
+        this.schemaName = schemaName;
+        this.selected = selected;
+        this.loadState = loadState;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public boolean isSelected() {
+        return selected;
+    }
+
+    public void setSelected(boolean selected) {
+        this.selected = selected;
+    }
+
+    public LoadState getLoadState() {
+        return loadState;
+    }
+
+    public void setLoadState(LoadState loadState) {
+        this.loadState = loadState;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SourceSchemaSummary)) {
+            return false;
+        }
+        SourceSchemaSummary other = (SourceSchemaSummary) obj;
+        return Objects.equals(schemaName, other.schemaName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemaName);
+    }
+
+    @Override
+    public String toString() {
+        return "SourceSchemaSummary{"
+                + "schemaName='"
+                + schemaName
+                + '\''
+                + ", selected="
+                + selected
+                + ", loadState="
+                + loadState
+                + '}';
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/SchemaFetcherWithProgress.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/SchemaFetcherWithProgress.java
@@ -33,6 +33,7 @@ package com.cubrid.cubridmigration.ui.database;
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbmetadata.DBSchemaInfoFetcherFactory;
+import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSchemaInfoFetcher;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSource;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
@@ -64,6 +65,7 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
     protected boolean isFinished;
     protected Exception exception;
     protected String errorMessage;
+    private IBuildSchemaFilter activeFilter;
 
     protected SchemaFetcherWithProgress() {
         //
@@ -133,11 +135,12 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
     protected Thread startFetchingThread(
             final IDBSchemaInfoFetcher fetcher, final IProgressMonitor pm) {
         pm.beginTask(Messages.progressMetadata, IProgressMonitor.UNKNOWN);
+        final IBuildSchemaFilter filter = activeFilter;
         Thread thread =
                 new Thread("Cancel progress") {
                     public void run() {
                         try {
-                            catalog = fetcher.fetchSchema(dbSource, null);
+                            catalog = fetcher.fetchSchema(dbSource, filter);
                         } catch (Exception ex) {
                             exception = ex;
                             LOG.error("", ex);
@@ -156,7 +159,19 @@ public class SchemaFetcherWithProgress implements IRunnableWithProgress {
      * @return Catalog
      */
     public Catalog fetch() {
+        return fetch(null);
+    }
+
+    /**
+     * return catalog with progress dialog
+     *
+     * @param filter schema filter
+     * @return Catalog
+     */
+    public Catalog fetch(IBuildSchemaFilter filter) {
+        activeFilter = filter;
         CompositeUtils.runMethodInProgressBar(true, true, this);
+        activeFilter = null;
         return catalog;
     }
 

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/provider/CatalogAssembler.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/provider/CatalogAssembler.java
@@ -1,0 +1,15 @@
+package com.cubrid.cubridmigration.ui.database.provider;
+
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceMetadataSession;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import java.util.Collection;
+
+/**
+ * Helper responsible for composing a working {@link Catalog} from session fragments.
+ */
+public class CatalogAssembler {
+
+    public Catalog buildCatalog(SourceMetadataSession session, Collection<String> schemaNames) {
+        throw new UnsupportedOperationException("buildCatalog has not been implemented yet");
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/provider/JdbcSourceMetadataProvider.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/provider/JdbcSourceMetadataProvider.java
@@ -1,0 +1,33 @@
+package com.cubrid.cubridmigration.ui.database.provider;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.session.CatalogHeader;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceMetadataSession;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceSchemaSummary;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import java.util.Collection;
+import java.util.List;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * JDBC-based implementation of {@link SourceMetadataProvider}. The concrete loading logic will be
+ * provided in later phases once the wizard consumes the new lazy-loading infrastructure.
+ */
+public class JdbcSourceMetadataProvider implements SourceMetadataProvider {
+
+    @Override
+    public CatalogHeader loadHeader(ConnParameters connParameters) {
+        throw new UnsupportedOperationException("loadHeader has not been implemented yet");
+    }
+
+    @Override
+    public List<SourceSchemaSummary> listSchemas(SourceMetadataSession session) {
+        throw new UnsupportedOperationException("listSchemas has not been implemented yet");
+    }
+
+    @Override
+    public Catalog loadSchemaDetails(
+            SourceMetadataSession session, Collection<String> schemaNames, IProgressMonitor monitor) {
+        throw new UnsupportedOperationException("loadSchemaDetails has not been implemented yet");
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/provider/SourceMetadataProvider.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/provider/SourceMetadataProvider.java
@@ -1,0 +1,23 @@
+package com.cubrid.cubridmigration.ui.database.provider;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.session.CatalogHeader;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceMetadataSession;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceSchemaSummary;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import java.util.Collection;
+import java.util.List;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * Abstraction over metadata retrieval so the wizard can load schema details on demand.
+ */
+public interface SourceMetadataProvider {
+
+    CatalogHeader loadHeader(ConnParameters connParameters);
+
+    List<SourceSchemaSummary> listSchemas(SourceMetadataSession session);
+
+    Catalog loadSchemaDetails(
+            SourceMetadataSession session, Collection<String> schemaNames, IProgressMonitor monitor);
+}

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizard.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizard.java
@@ -31,12 +31,14 @@
 package com.cubrid.cubridmigration.ui.wizard;
 
 import com.cubrid.common.log.LogUtil;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceMetadataSession;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.template.reader.MigrationTemplateReader;
 import com.cubrid.cubridmigration.core.engine.template.writer.MigrationTemplateWriter;
 import com.cubrid.cubridmigration.cubrid.CUBRIDTimeUtil;
+import com.cubrid.cubridmigration.ui.database.provider.SourceMetadataProvider;
 import com.cubrid.cubridmigration.ui.common.UICommonTool;
 import com.cubrid.cubridmigration.ui.common.navigator.event.CubridNodeManager;
 import com.cubrid.cubridmigration.ui.common.navigator.node.DatabaseNode;
@@ -132,6 +134,9 @@ public class MigrationWizard extends Wizard implements IMigrationWizardStatus {
     protected Catalog originalSourceCatalog;
     protected Catalog targetCatalog;
 
+    protected SourceMetadataSession sourceMetadataSession;
+    protected SourceMetadataProvider sourceMetadataProvider;
+
     protected DatabaseNode sourceDBNode;
 
     private boolean saveSchema;
@@ -146,6 +151,7 @@ public class MigrationWizard extends Wizard implements IMigrationWizardStatus {
         migrationConfig = new MigrationConfiguration();
         migrationConfig.setWizardStartDateTime(
                 CUBRIDTimeUtil.wizardStarDateTimeFormat(new Date(System.currentTimeMillis())));
+        sourceMetadataSession = new SourceMetadataSession();
     }
 
     public MigrationWizard(MigrationScript migrationScript) {
@@ -336,6 +342,29 @@ public class MigrationWizard extends Wizard implements IMigrationWizardStatus {
      */
     public Catalog getTargetCatalog() {
         return targetCatalog;
+    }
+
+    public SourceMetadataSession getSourceMetadataSession() {
+        if (sourceMetadataSession == null) {
+            sourceMetadataSession = new SourceMetadataSession();
+        }
+        return sourceMetadataSession;
+    }
+
+    public void setSourceMetadataSession(SourceMetadataSession sourceMetadataSession) {
+        if (sourceMetadataSession == null) {
+            this.sourceMetadataSession = new SourceMetadataSession();
+        } else {
+            this.sourceMetadataSession = sourceMetadataSession;
+        }
+    }
+
+    public SourceMetadataProvider getSourceMetadataProvider() {
+        return sourceMetadataProvider;
+    }
+
+    public void setSourceMetadataProvider(SourceMetadataProvider sourceMetadataProvider) {
+        this.sourceMetadataProvider = sourceMetadataProvider;
     }
 
     public boolean isLoadMigrationScript() {

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizardFactory.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizardFactory.java
@@ -31,6 +31,7 @@
 package com.cubrid.cubridmigration.ui.wizard;
 
 import com.cubrid.cubridmigration.core.common.PathUtils;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceMetadataSession;
 import com.cubrid.cubridmigration.core.engine.MigrationProcessManager;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.config.SourceCSVConfig;
@@ -58,6 +59,8 @@ import com.cubrid.cubridmigration.ui.wizard.dialog.MigrationWizardDialog;
 import com.cubrid.cubridmigration.ui.wizard.editor.CSVProgressEditorPart;
 import com.cubrid.cubridmigration.ui.wizard.editor.MigrationProgressEditorPart;
 import com.cubrid.cubridmigration.ui.wizard.editor.SQLProgressEditorPart;
+import com.cubrid.cubridmigration.ui.database.provider.JdbcSourceMetadataProvider;
+import com.cubrid.cubridmigration.ui.database.provider.SourceMetadataProvider;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -93,7 +96,8 @@ public final class MigrationWizardFactory {
         if (MigrationWizardFactory.migrationIsRunning()) {
             return;
         }
-        Wizard wizard = new MigrationWizard(script);
+        MigrationWizard wizard = new MigrationWizard(script);
+        configureMetadataSupport(wizard);
         Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
         MigrationWizardDialog dialog = new MigrationWizardDialog(shell, wizard);
         openWizardDlg(dialog);
@@ -119,7 +123,8 @@ public final class MigrationWizardFactory {
         if (MigrationWizardFactory.migrationIsRunning()) {
             return;
         }
-        Wizard wizard = new MigrationWizard(script);
+        MigrationWizard wizard = new MigrationWizard(script);
+        configureMetadataSupport(wizard);
         Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
         MigrationWizardDialog dialog = new MigrationWizardDialog(shell, wizard);
         openWizardDlg(dialog);
@@ -147,6 +152,7 @@ public final class MigrationWizardFactory {
         Shell activeShell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
 
         MigrationWizard wizard = new MigrationWizard();
+        configureMetadataSupport(wizard);
 
         MigrationWizardDialog dialog = new MigrationWizardDialog(activeShell, wizard);
 
@@ -161,6 +167,7 @@ public final class MigrationWizardFactory {
         Shell activeShell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
 
         MigrationWizard wizard = new MigrationWizard();
+        configureMetadataSupport(wizard);
         MigrationWizardDialog dialog = new MigrationWizardDialog(activeShell, wizard);
         openWizardDlg(dialog);
     }
@@ -172,9 +179,22 @@ public final class MigrationWizardFactory {
         }
         Shell activeShell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
 
-        MigrationWizardDialog dialog =
-                new MigrationWizardDialog(activeShell, new MigrationWizard());
+        MigrationWizard wizard = new MigrationWizard();
+        configureMetadataSupport(wizard);
+        MigrationWizardDialog dialog = new MigrationWizardDialog(activeShell, wizard);
         openWizardDlg(dialog);
+    }
+
+    private static void configureMetadataSupport(MigrationWizard wizard) {
+        SourceMetadataSession session = wizard.getSourceMetadataSession();
+        if (session == null) {
+            session = new SourceMetadataSession();
+            wizard.setSourceMetadataSession(session);
+        }
+        SourceMetadataProvider provider = wizard.getSourceMetadataProvider();
+        if (provider == null) {
+            wizard.setSourceMetadataProvider(new JdbcSourceMetadataProvider());
+        }
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
@@ -33,6 +33,9 @@ package com.cubrid.cubridmigration.ui.wizard.page;
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.common.TimeZoneUtils;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.session.CatalogHeader;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceMetadataSession;
+import com.cubrid.cubridmigration.core.dbmetadata.session.SourceSchemaSummary;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbobject.Grant;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
@@ -47,6 +50,7 @@ import com.cubrid.cubridmigration.ui.database.DatabaseConnectionInfo;
 import com.cubrid.cubridmigration.ui.database.IJDBCConnectionFilter;
 import com.cubrid.cubridmigration.ui.database.JDBCConnectionMgrView;
 import com.cubrid.cubridmigration.ui.database.MysqlXmlDumpSchemaProgressFetcher;
+import com.cubrid.cubridmigration.ui.database.provider.SourceMetadataProvider;
 import com.cubrid.cubridmigration.ui.message.Messages;
 import com.cubrid.cubridmigration.ui.wizard.MigrationWizard;
 import com.cubrid.cubridmigration.ui.wizard.dialog.RenameSchemaDialog;
@@ -536,6 +540,8 @@ public class SelectSourcePage extends MigrationWizardPage {
                 return false;
             }
 
+            refreshMetadataSession(wzd, catalog);
+
             if (catalog.getDatabaseType().getID() == 1) {
                 removeEmptySchema(catalog);
             }
@@ -592,6 +598,58 @@ public class SelectSourcePage extends MigrationWizardPage {
                 }
             }
             return true;
+        }
+
+        private void refreshMetadataSession(MigrationWizard wizard, Catalog catalog) {
+            SourceMetadataSession session = wizard.getSourceMetadataSession();
+            if (session == null) {
+                session = new SourceMetadataSession();
+                wizard.setSourceMetadataSession(session);
+            }
+
+            ConnParameters connParameters = catalog.getConnectionParameters();
+            session.reset(connParameters);
+
+            SourceMetadataProvider provider = wizard.getSourceMetadataProvider();
+            boolean headerAssigned = false;
+            if (provider != null && connParameters != null) {
+                try {
+                    CatalogHeader header = provider.loadHeader(connParameters);
+                    if (header != null) {
+                        session.setHeader(header);
+                        headerAssigned = true;
+                    }
+                } catch (UnsupportedOperationException ex) {
+                    LOG.debug("Source metadata provider header loading not yet available", ex);
+                } catch (Exception ex) {
+                    LOG.warn("Failed to load catalog header through source metadata provider", ex);
+                }
+
+                try {
+                    List<SourceSchemaSummary> summaries = provider.listSchemas(session);
+                    if (summaries != null) {
+                        for (SourceSchemaSummary summary : summaries) {
+                            session.putSummary(summary);
+                        }
+                    }
+                } catch (UnsupportedOperationException ex) {
+                    LOG.debug("Source metadata provider schema listing not yet available", ex);
+                } catch (Exception ex) {
+                    LOG.warn("Failed to enumerate schemas through source metadata provider", ex);
+                }
+            }
+
+            if (!headerAssigned) {
+                String version = catalog.getVersion() == null ? null : catalog.getVersion().toString();
+                String timeZone = catalog.getAdditionalInfo().get(Catalog.KEY_DB_TIMEZONE);
+                session.setHeader(new CatalogHeader(catalog.getName(), version, timeZone));
+            }
+
+            if (session.getSummaries().isEmpty()) {
+                for (Schema schema : catalog.getSchemas()) {
+                    session.putSummary(new SourceSchemaSummary(schema.getName()));
+                }
+            }
         }
 
         /**


### PR DESCRIPTION
## Summary
- reset and populate the metadata session when an online source catalog is saved in the wizard
- capture fallback header and schema summaries whenever the provider cannot supply lazy data yet

## Testing
- `mvn -pl plugins/com.cubrid.cubridmigration.ui -am -DskipTests compile` *(fails: missing org.eclipse.tycho:tycho-maven-plugin:4.0.13 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f119ae7c8323998c9f0522e7af91)